### PR TITLE
FEATURE: adds support for rate limit when requests are queuing

### DIFF
--- a/app/controllers/discourse_tooltips/tooltip_previews_controller.rb
+++ b/app/controllers/discourse_tooltips/tooltip_previews_controller.rb
@@ -3,6 +3,8 @@
 module DiscourseTooltips
   class TooltipPreviewsController < ApplicationController
     requires_plugin DiscourseTooltips::PLUGIN_NAME
+
+    before_action :rate_limit!
     skip_before_action :check_xhr
 
     def index
@@ -21,5 +23,14 @@ module DiscourseTooltips
       render json: { excerpts: excerpts }
     end
 
+    private
+
+    def rate_limit!
+      if queue_time = request.env["REQUEST_QUEUE_SECONDS"]
+        if queue_time > (SiteSetting.tooltips_rate_limit_queue_seconds).to_f
+          raise RateLimiter::LimitExceeded, 30 + (rand * 120).to_i
+        end
+      end
+    end
   end
 end

--- a/assets/javascripts/mixins/topic-hover-extension.js.es6
+++ b/assets/javascripts/mixins/topic-hover-extension.js.es6
@@ -47,6 +47,8 @@ function renderTooltip($this, text) {
   $dTooltip.fadeIn(200);
 }
 
+let tooltipsRateLimited = false;
+
 export function hoverExtension(selector) {
   return {
     didInsertElement() {
@@ -72,6 +74,10 @@ export function hoverExtension(selector) {
             return renderTooltip($this, _cached[topicId].excerpt);
           }
 
+          if (tooltipsRateLimited) {
+            return;
+          }
+
           let topicIds = [topicId];
 
           // Let's actually fetch the next few topic ids too, assuming the user will
@@ -89,6 +95,7 @@ export function hoverExtension(selector) {
           _promise = ajax("/tooltip-previews", {
             data: { topic_ids: topicIds }
           });
+
           _promise
             .then(r => {
               if (r && r.excerpts) {
@@ -99,7 +106,33 @@ export function hoverExtension(selector) {
                 renderTooltip($this, _cached[topicId].excerpt);
               }
             })
-            .catch(() => {
+            .catch(event => {
+              const xhr = event.jqXHR;
+              if (xhr && xhr.status === 429) {
+                tooltipsRateLimited = true;
+
+                let tryAfter =
+                  parseInt(
+                    xhr.getResponseHeader &&
+                      xhr.getResponseHeader("Retry-After"),
+                    10
+                  ) || 0;
+
+                tryAfter = tryAfter || 0;
+
+                if (tryAfter < 15) {
+                  tryAfter = 15;
+                }
+
+                this.rateLimiter = Ember.run.later(
+                  this,
+                  () => {
+                    tooltipsRateLimited = false;
+                  },
+                  tryAfter * 1000
+                );
+              }
+
               // swallow errors - was probably aborted!
             });
         }
@@ -111,6 +144,9 @@ export function hoverExtension(selector) {
     },
 
     willDestroyElement() {
+      Ember.run.cancel(this.rateLimiter);
+      tooltipsRateLimited = false;
+
       this._super(...arguments);
 
       if (this.capabilities.touch) {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,5 @@
 plugins:
   tooltips_enabled:
     default: true
+  tooltips_rate_limit_queue_seconds:
+    default: 0.1

--- a/spec/integration/rate_limiting_spec.rb
+++ b/spec/integration/rate_limiting_spec.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "RateLimiting previews" do
+  before do
+    SiteSetting.tooltips_rate_limit_queue_seconds = 0.1
+  end
+
+  let(:topic) { Fabricate(:topic) }
+
+  it "will rate limit previews once queuing" do
+    freeze_time
+
+    get "/tooltip-previews",
+      params: {
+        topic_ids: [ topic.id ]
+      },
+      headers: {
+        "HTTP_X_REQUEST_START" => "t=#{Time.now.to_f - 0.2}"
+      }
+
+    expect(response.status).to eq(429)
+    expect(response.headers['Retry-After']).to be > 29
+  end
+
+  it "will not rate limit when all is good" do
+    freeze_time
+
+    get "/tooltip-previews",
+      params: {
+        topic_ids: [ topic.id ]
+      },
+      headers: {
+        "HTTP_X_REQUEST_START" => "t=#{Time.now.to_f - 0.05}"
+      }
+
+    expect(response.status).to eq(200)
+  end
+end


### PR DESCRIPTION
This will return a 429 when server is queuing for more than `tooltips_rate_limit_queue_seconds`(default 0.1). Once this has been triggered tooltips requests will be prevented on client for 30 + (rand * 120) seconds