### PR TITLE
DEV: Header values can be strings

### DIFF
--- a/spec/integration/rate_limiting_spec.rb
+++ b/spec/integration/rate_limiting_spec.rb
@@ -22,7 +22,7 @@ describe "RateLimiting previews" do
       }
 
     expect(response.status).to eq(429)
-    expect(response.headers['Retry-After']).to be > 29
+    expect(response.headers['Retry-After'].to_i).to be > 29
   end
 
   it "will not rate limit when all is good" do


### PR DESCRIPTION
Fixes the spec failure in https://github.com/discourse/discourse/pull/12475