### PR TITLE
FEATURE: Better detect mouse/touch using event-from

### DIFF
--- a/assets/javascripts/discourse/lib/event-from.js.es6
+++ b/assets/javascripts/discourse/lib/event-from.js.es6
@@ -1,0 +1,181 @@
+let recentEventFrom = 'key';
+let recentFocusFrom = recentEventFrom;
+let recentTouch = false;
+let recentMouse = false;
+let recentWindowFocus = false;
+// To determine if there was a recentTouch event
+// use setTimeout instead of a Date.now() comparison because
+// in the case of a long running/blocking process from a touch event,
+// the browser will push the corresponding mouse event (created by the touch interaction)
+// onto the callback queue at the time it should be executed,
+// and then push the timeout function onto the queue after the timer expires,
+// even if the the main thread is still blocked (because the browser is multi-threaded).
+// This results in the mouse event being moved to the callstack and called
+// before the timeout function so recentTouch is still true
+// regardless of how many Date.now() seconds have gone by.
+// Also, if subsequent touch events occur while the blocking process is running,
+// the browser will push the touch events onto the queue when the touch happens,
+// and if one of them is in queue before the previous touch event's timer expires,
+// it will be called before the timeout's function (so it can reset the timer),
+// and, this is the key part, if the previous timer has finished and it's callback is added to the queue,
+// the call to clearTimeout(recentTouchTimeoutId) will remove the timeout's function from the callback queue.
+let recentTouchTimeoutId;
+const setRecentEventFromTouch = (touchDelay) => {
+    recentTouch = true;
+    recentEventFrom = 'touch';
+    window.clearTimeout(recentTouchTimeoutId);
+    recentTouchTimeoutId = window.setTimeout(() => {
+        recentTouch = false;
+    }, touchDelay);
+};
+let recentMouseTimeoutId;
+const setRecentEventFromMouse = () => {
+    recentMouse = true;
+    recentEventFrom = 'mouse';
+    window.clearTimeout(recentMouseTimeoutId);
+    recentMouseTimeoutId = window.setTimeout(() => {
+        recentMouse = false;
+    }, 200);
+};
+const handleTouchEvent = (touchDelay) => () => setRecentEventFromTouch(touchDelay);
+const handlePointerEvent = (touchDelay) => (e) => {
+    switch (e.pointerType) {
+        case 'mouse':
+            setRecentEventFromMouse();
+            break;
+        case 'pen':
+        case 'touch':
+            setRecentEventFromTouch(touchDelay);
+            break;
+    }
+};
+const handleMouseEvent = () => {
+    if (!recentTouch) {
+        setRecentEventFromMouse();
+    }
+};
+const handleKeyEvent = () => {
+    recentEventFrom = 'key';
+};
+// recentFocusFrom tracking
+// set document focus event capture listener which sets recentFocusFrom equal to recentEventFrom
+// except if there is a recent window focus event where the window is the target (unless there is also a recent mouse or touch event),
+// in which case leave recentFocusFrom unchanged to maintain correct recentFocusFrom after switching apps/windows/tabs/etc,
+// if/when the focus event is passed into eventFrom later in the cycle, just return recentFocusFrom.
+// for tracking recent window focus, set window focus capture event listener,
+// if the target is window (or document on firefox), then track recentWindowFocus with setTimeout 300
+let recentWindowFocusTimeoutId;
+const handleWindowFocusEvent = (e) => {
+    if (e.target === window || e.target === document) {
+        recentWindowFocus = true;
+        window.clearTimeout(recentWindowFocusTimeoutId);
+        recentWindowFocusTimeoutId = window.setTimeout(() => {
+            recentWindowFocus = false;
+        }, 300);
+    }
+};
+const handleDocumentFocusEvent = () => {
+    if (!recentWindowFocus || recentMouse || recentTouch) {
+        recentFocusFrom = recentEventFrom;
+    }
+};
+const listenerOptions = { capture: true, passive: true };
+const documentListeners = [
+    ['touchstart', handleTouchEvent(750)],
+    ['touchend', handleTouchEvent(300)],
+    ['touchcancel', handleTouchEvent(300)],
+    ['pointerenter', handlePointerEvent(300)],
+    ['pointerover', handlePointerEvent(300)],
+    ['pointerout', handlePointerEvent(300)],
+    ['pointerleave', handlePointerEvent(300)],
+    ['pointerdown', handlePointerEvent(750)],
+    ['pointerup', handlePointerEvent(300)],
+    ['pointercancel', handlePointerEvent(300)],
+    ['mouseenter', handleMouseEvent],
+    ['mouseover', handleMouseEvent],
+    ['mouseout', handleMouseEvent],
+    ['mouseleave', handleMouseEvent],
+    ['mousedown', handleMouseEvent],
+    ['mouseup', handleMouseEvent],
+    ['keydown', handleKeyEvent],
+    ['keyup', handleKeyEvent],
+    ['focus', handleDocumentFocusEvent],
+];
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    documentListeners.forEach(([eventName, eventHandler]) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore not sure how to get TS to match the handler type to the specific eventName
+        document.addEventListener(eventName, eventHandler, listenerOptions);
+    });
+    window.addEventListener('focus', handleWindowFocusEvent, listenerOptions);
+}
+// temporarily set the return value for eventFrom(e)
+// note that the eventFrom(e) value will change when new events come in
+// useful when manually generating events, e.g. el.focus() or el.click()
+// and you want eventFrom(e) to treat that event as occurring from a specific input
+const setEventFrom = (value) => {
+    if (process.env.NODE_ENV !== 'production') {
+        if (value !== 'mouse' && value !== 'touch' && value !== 'key') {
+            throw Error(`setEventFrom function requires argument of "mouse" | "touch" | "key", argument received: ${value}`);
+        }
+    }
+    if (value === 'mouse' || value === 'touch' || value === 'key') {
+        recentEventFrom = value;
+        recentFocusFrom = value;
+    }
+};
+// use any instead of unknown b/c unknown causes type error when passing a react synthetic event
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const eventFrom = (event) => {
+    // use the incoming event to help determine recentEventFrom
+    // in the same manner as the document event listeners
+    // this helps catch edge cases especially when a move event is passed to eventFrom
+    // because move event listeners are not set by Event From
+    switch (event.pointerType) {
+        case 'mouse':
+            setRecentEventFromMouse();
+            break;
+        case 'pen':
+        case 'touch':
+            if (!recentTouch) {
+                setRecentEventFromTouch(300);
+            }
+            else {
+                recentEventFrom = 'touch';
+            }
+            break;
+    }
+    if (/mouse/.test(event.type) && !recentTouch) {
+        setRecentEventFromMouse();
+    }
+    if (/touch/.test(event.type)) {
+        if (!recentTouch) {
+            setRecentEventFromTouch(300);
+        }
+        else {
+            recentEventFrom = 'touch';
+        }
+    }
+    // focus events return recentFocusFrom, see recentFocusFrom tracking note above
+    if (/focus/.test(event.type)) {
+        return recentFocusFrom;
+    }
+    return recentEventFrom;
+};
+// note that edge cases exist for scroll and wheel events where eventFrom will return the wrong input,
+// to fix this, event-from would need to set a 'wheel' event listener on the document (see below),
+// but decided not to add it because 'wheel' is a high frequency event (like move events)
+// and don't currently have a use case for eventFrom(scrollEvent)
+// to add support:
+//   document.addEventListener(
+//     'wheel',
+//     () => {
+//       // might need to track wheel event separately and use it just for eventFrom(scroll)
+//       // because the wheel event is elastic, it continues to fire after the user interaction has finished
+//       recentEventFrom = 'mouse';
+//     },
+//     listenerOptions,
+//   );
+
+export { eventFrom, setEventFrom };
+//# sourceMappingURL=event-from.esm.js.map

--- a/assets/javascripts/discourse/lib/event-from.js.es6
+++ b/assets/javascripts/discourse/lib/event-from.js.es6
@@ -1,4 +1,4 @@
-let recentEventFrom = 'key';
+let recentEventFrom = "key";
 let recentFocusFrom = recentEventFrom;
 let recentTouch = false;
 let recentMouse = false;
@@ -21,41 +21,42 @@ let recentWindowFocus = false;
 // the call to clearTimeout(recentTouchTimeoutId) will remove the timeout's function from the callback queue.
 let recentTouchTimeoutId;
 const setRecentEventFromTouch = (touchDelay) => {
-    recentTouch = true;
-    recentEventFrom = 'touch';
-    window.clearTimeout(recentTouchTimeoutId);
-    recentTouchTimeoutId = window.setTimeout(() => {
-        recentTouch = false;
-    }, touchDelay);
+  recentTouch = true;
+  recentEventFrom = "touch";
+  window.clearTimeout(recentTouchTimeoutId);
+  recentTouchTimeoutId = window.setTimeout(() => {
+    recentTouch = false;
+  }, touchDelay);
 };
 let recentMouseTimeoutId;
 const setRecentEventFromMouse = () => {
-    recentMouse = true;
-    recentEventFrom = 'mouse';
-    window.clearTimeout(recentMouseTimeoutId);
-    recentMouseTimeoutId = window.setTimeout(() => {
-        recentMouse = false;
-    }, 200);
+  recentMouse = true;
+  recentEventFrom = "mouse";
+  window.clearTimeout(recentMouseTimeoutId);
+  recentMouseTimeoutId = window.setTimeout(() => {
+    recentMouse = false;
+  }, 200);
 };
-const handleTouchEvent = (touchDelay) => () => setRecentEventFromTouch(touchDelay);
+const handleTouchEvent = (touchDelay) => () =>
+  setRecentEventFromTouch(touchDelay);
 const handlePointerEvent = (touchDelay) => (e) => {
-    switch (e.pointerType) {
-        case 'mouse':
-            setRecentEventFromMouse();
-            break;
-        case 'pen':
-        case 'touch':
-            setRecentEventFromTouch(touchDelay);
-            break;
-    }
+  switch (e.pointerType) {
+    case "mouse":
+      setRecentEventFromMouse();
+      break;
+    case "pen":
+    case "touch":
+      setRecentEventFromTouch(touchDelay);
+      break;
+  }
 };
 const handleMouseEvent = () => {
-    if (!recentTouch) {
-        setRecentEventFromMouse();
-    }
+  if (!recentTouch) {
+    setRecentEventFromMouse();
+  }
 };
 const handleKeyEvent = () => {
-    recentEventFrom = 'key';
+  recentEventFrom = "key";
 };
 // recentFocusFrom tracking
 // set document focus event capture listener which sets recentFocusFrom equal to recentEventFrom
@@ -66,101 +67,101 @@ const handleKeyEvent = () => {
 // if the target is window (or document on firefox), then track recentWindowFocus with setTimeout 300
 let recentWindowFocusTimeoutId;
 const handleWindowFocusEvent = (e) => {
-    if (e.target === window || e.target === document) {
-        recentWindowFocus = true;
-        window.clearTimeout(recentWindowFocusTimeoutId);
-        recentWindowFocusTimeoutId = window.setTimeout(() => {
-            recentWindowFocus = false;
-        }, 300);
-    }
+  if (e.target === window || e.target === document) {
+    recentWindowFocus = true;
+    window.clearTimeout(recentWindowFocusTimeoutId);
+    recentWindowFocusTimeoutId = window.setTimeout(() => {
+      recentWindowFocus = false;
+    }, 300);
+  }
 };
 const handleDocumentFocusEvent = () => {
-    if (!recentWindowFocus || recentMouse || recentTouch) {
-        recentFocusFrom = recentEventFrom;
-    }
+  if (!recentWindowFocus || recentMouse || recentTouch) {
+    recentFocusFrom = recentEventFrom;
+  }
 };
 const listenerOptions = { capture: true, passive: true };
 const documentListeners = [
-    ['touchstart', handleTouchEvent(750)],
-    ['touchend', handleTouchEvent(300)],
-    ['touchcancel', handleTouchEvent(300)],
-    ['pointerenter', handlePointerEvent(300)],
-    ['pointerover', handlePointerEvent(300)],
-    ['pointerout', handlePointerEvent(300)],
-    ['pointerleave', handlePointerEvent(300)],
-    ['pointerdown', handlePointerEvent(750)],
-    ['pointerup', handlePointerEvent(300)],
-    ['pointercancel', handlePointerEvent(300)],
-    ['mouseenter', handleMouseEvent],
-    ['mouseover', handleMouseEvent],
-    ['mouseout', handleMouseEvent],
-    ['mouseleave', handleMouseEvent],
-    ['mousedown', handleMouseEvent],
-    ['mouseup', handleMouseEvent],
-    ['keydown', handleKeyEvent],
-    ['keyup', handleKeyEvent],
-    ['focus', handleDocumentFocusEvent],
+  ["touchstart", handleTouchEvent(750)],
+  ["touchend", handleTouchEvent(300)],
+  ["touchcancel", handleTouchEvent(300)],
+  ["pointerenter", handlePointerEvent(300)],
+  ["pointerover", handlePointerEvent(300)],
+  ["pointerout", handlePointerEvent(300)],
+  ["pointerleave", handlePointerEvent(300)],
+  ["pointerdown", handlePointerEvent(750)],
+  ["pointerup", handlePointerEvent(300)],
+  ["pointercancel", handlePointerEvent(300)],
+  ["mouseenter", handleMouseEvent],
+  ["mouseover", handleMouseEvent],
+  ["mouseout", handleMouseEvent],
+  ["mouseleave", handleMouseEvent],
+  ["mousedown", handleMouseEvent],
+  ["mouseup", handleMouseEvent],
+  ["keydown", handleKeyEvent],
+  ["keyup", handleKeyEvent],
+  ["focus", handleDocumentFocusEvent],
 ];
-if (typeof window !== 'undefined' && typeof document !== 'undefined') {
-    documentListeners.forEach(([eventName, eventHandler]) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore not sure how to get TS to match the handler type to the specific eventName
-        document.addEventListener(eventName, eventHandler, listenerOptions);
-    });
-    window.addEventListener('focus', handleWindowFocusEvent, listenerOptions);
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  documentListeners.forEach(([eventName, eventHandler]) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore not sure how to get TS to match the handler type to the specific eventName
+    document.addEventListener(eventName, eventHandler, listenerOptions);
+  });
+  window.addEventListener("focus", handleWindowFocusEvent, listenerOptions);
 }
 // temporarily set the return value for eventFrom(e)
 // note that the eventFrom(e) value will change when new events come in
 // useful when manually generating events, e.g. el.focus() or el.click()
 // and you want eventFrom(e) to treat that event as occurring from a specific input
 const setEventFrom = (value) => {
-    if (process.env.NODE_ENV !== 'production') {
-        if (value !== 'mouse' && value !== 'touch' && value !== 'key') {
-            throw Error(`setEventFrom function requires argument of "mouse" | "touch" | "key", argument received: ${value}`);
-        }
+  if (process.env.NODE_ENV !== "production") {
+    if (value !== "mouse" && value !== "touch" && value !== "key") {
+      throw Error(
+        `setEventFrom function requires argument of "mouse" | "touch" | "key", argument received: ${value}`
+      );
     }
-    if (value === 'mouse' || value === 'touch' || value === 'key') {
-        recentEventFrom = value;
-        recentFocusFrom = value;
-    }
+  }
+  if (value === "mouse" || value === "touch" || value === "key") {
+    recentEventFrom = value;
+    recentFocusFrom = value;
+  }
 };
 // use any instead of unknown b/c unknown causes type error when passing a react synthetic event
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const eventFrom = (event) => {
-    // use the incoming event to help determine recentEventFrom
-    // in the same manner as the document event listeners
-    // this helps catch edge cases especially when a move event is passed to eventFrom
-    // because move event listeners are not set by Event From
-    switch (event.pointerType) {
-        case 'mouse':
-            setRecentEventFromMouse();
-            break;
-        case 'pen':
-        case 'touch':
-            if (!recentTouch) {
-                setRecentEventFromTouch(300);
-            }
-            else {
-                recentEventFrom = 'touch';
-            }
-            break;
+  // use the incoming event to help determine recentEventFrom
+  // in the same manner as the document event listeners
+  // this helps catch edge cases especially when a move event is passed to eventFrom
+  // because move event listeners are not set by Event From
+  switch (event.pointerType) {
+    case "mouse":
+      setRecentEventFromMouse();
+      break;
+    case "pen":
+    case "touch":
+      if (!recentTouch) {
+        setRecentEventFromTouch(300);
+      } else {
+        recentEventFrom = "touch";
+      }
+      break;
+  }
+  if (/mouse/.test(event.type) && !recentTouch) {
+    setRecentEventFromMouse();
+  }
+  if (/touch/.test(event.type)) {
+    if (!recentTouch) {
+      setRecentEventFromTouch(300);
+    } else {
+      recentEventFrom = "touch";
     }
-    if (/mouse/.test(event.type) && !recentTouch) {
-        setRecentEventFromMouse();
-    }
-    if (/touch/.test(event.type)) {
-        if (!recentTouch) {
-            setRecentEventFromTouch(300);
-        }
-        else {
-            recentEventFrom = 'touch';
-        }
-    }
-    // focus events return recentFocusFrom, see recentFocusFrom tracking note above
-    if (/focus/.test(event.type)) {
-        return recentFocusFrom;
-    }
-    return recentEventFrom;
+  }
+  // focus events return recentFocusFrom, see recentFocusFrom tracking note above
+  if (/focus/.test(event.type)) {
+    return recentFocusFrom;
+  }
+  return recentEventFrom;
 };
 // note that edge cases exist for scroll and wheel events where eventFrom will return the wrong input,
 // to fix this, event-from would need to set a 'wheel' event listener on the document (see below),

--- a/assets/javascripts/discourse/lib/event-from.js.es6
+++ b/assets/javascripts/discourse/lib/event-from.js.es6
@@ -1,3 +1,6 @@
+/* eslint-disable */
+// prettier-ignore
+
 let recentEventFrom = "key";
 let recentFocusFrom = recentEventFrom;
 let recentTouch = false;

--- a/assets/javascripts/mixins/topic-hover-extension.js.es6
+++ b/assets/javascripts/mixins/topic-hover-extension.js.es6
@@ -1,5 +1,6 @@
 import { ajax } from "discourse/lib/ajax";
 import { deepMerge } from "discourse-common/lib/object";
+import { eventFrom } from "discourse/plugins/discourse-tooltips/discourse/lib/event-from";
 
 // How many extra post excerpts to retrieve
 const READ_AHEAD = 4;
@@ -57,16 +58,16 @@ export function hoverExtension(selector) {
     didInsertElement() {
       this._super(...arguments);
 
-      if (this.capabilities.touch) {
-        return;
-      }
-
       cancel();
 
       $(this.element).on(
         "mouseenter.discourse-tooltips",
         selector,
         function (e) {
+          if (eventFrom(e) !== "mouse") {
+            return;
+          }
+
           let $this = $(this);
 
           let $parentTopicId = $(e.currentTarget);
@@ -149,9 +150,13 @@ export function hoverExtension(selector) {
         }
       );
 
-      $(this.element).on("mouseleave.discourse-tooltips", selector, () =>
-        cleanDom()
-      );
+      $(this.element).on("mouseleave.discourse-tooltips", selector, (e) => {
+        if (eventFrom(e) !== "mouse") {
+          return;
+        }
+
+        cleanDom();
+      });
     },
 
     willDestroyElement() {
@@ -159,10 +164,6 @@ export function hoverExtension(selector) {
       tooltipsRateLimited = false;
 
       this._super(...arguments);
-
-      if (this.capabilities.touch) {
-        return;
-      }
 
       cancel();
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Discourse",
   "license": "MIT",
   "devDependencies": {
-    "eslint-config-discourse": "^1.1.8"
+  "eslint-config-discourse": "^1.1.9"
   },
   "dependencies": {
     "event-from": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -6,5 +6,11 @@
   "license": "MIT",
   "devDependencies": {
     "eslint-config-discourse": "^1.1.8"
+  },
+  "dependencies": {
+    "event-from": "^1.0.0"
+  },
+  "scripts": {
+    "postinstall": "cp node_modules/event-from/dist/event-from.esm.js assets/javascripts/discourse/lib/event-from.js.es6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,5 @@
   },
   "dependencies": {
     "event-from": "^1.0.0"
-  },
-  "scripts": {
-    "postinstall": "cp node_modules/event-from/dist/event-from.esm.js assets/javascripts/discourse/lib/event-from.js.es6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Discourse",
   "license": "MIT",
   "devDependencies": {
-  "eslint-config-discourse": "^1.1.9"
+    "eslint-config-discourse": "^1.1.9"
   },
   "dependencies": {
     "event-from": "^1.0.0"

--- a/test/javascripts/acceptance/discourse-tooltips-test.js.es6
+++ b/test/javascripts/acceptance/discourse-tooltips-test.js.es6
@@ -21,7 +21,7 @@ acceptance("Discourse Tooltips", function (needs) {
 
   test("display and hide", async function (assert) {
     await visit("/latest");
-    assert.equal(find(".d-tooltip").length, 0, "tooltip is hidden");
+    assert.ok(!visible(".d-tooltip"), "tooltip is hidden");
 
     let topicLink = query(".topic-list-item:first-child .raw-topic-link");
 

--- a/test/javascripts/acceptance/discourse-tooltips-test.js.es6
+++ b/test/javascripts/acceptance/discourse-tooltips-test.js.es6
@@ -1,4 +1,10 @@
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import {
+  acceptance,
+  query,
+  visible,
+} from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { triggerEvent, visit } from "@ember/test-helpers";
 
 acceptance("Discourse Tooltips", function (needs) {
   needs.pretender((server, helper) => {
@@ -13,28 +19,17 @@ acceptance("Discourse Tooltips", function (needs) {
     });
   });
 
-  test("display and hide", (assert) => {
-    visit("/latest");
+  test("display and hide", async function (assert) {
+    await visit("/latest");
+    assert.equal(find(".d-tooltip").length, 0, "tooltip is hidden");
 
-    andThen(() => {
-      assert.equal(find(".d-tooltip").length, 0, "tooltip is hidden");
-    });
+    let topicLink = query(".topic-list-item:first-child .raw-topic-link");
 
-    andThen(() => {
-      let topic = find(".topic-list-item[data-topic-id=11557] .raw-topic-link");
-      topic.trigger("mouseenter");
-    });
+    await triggerEvent(topicLink, "mouseover");
+    assert.ok(visible(".d-tooltip"), "tooltip is shown");
+    assert.equal(query(".d-tooltip-content").textContent.trim(), "hello world");
 
-    andThen(() => {
-      assert.equal(find(".d-tooltip").length, 1, "tooltip is shown");
-      assert.equal(find(".d-tooltip-content").text(), "hello world");
-
-      let topic = find(".topic-list-item[data-topic-id=11557] .raw-topic-link");
-      topic.trigger("mouseleave");
-    });
-
-    andThen(() => {
-      assert.equal(find(".d-tooltip").length, 0, "tooltip is hidden again");
-    });
+    await triggerEvent(topicLink, "mouseout");
+    assert.notOk(visible(".d-tooltip"), "tooltip is hidden again");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,10 +498,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-discourse@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/eslint-config-discourse/-/eslint-config-discourse-1.1.8.tgz#c297831876811ea08203aa348d1ba2a963b2ae78"
-  integrity sha512-ZSQfhliiO5Cfa7WcKoMkN4wW/1rBJpecpMJpfjiFsElfgPj4EV4Pzksi5CvFnRbJDoZh6DYYrQfO+tW062VOUA==
+eslint-config-discourse@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/eslint-config-discourse/-/eslint-config-discourse-1.1.9.tgz#9a5ee6b3a4b986e5243f517e7945d1709c4e22df"
+  integrity sha512-a4KG+/9/7ZhYVV0URGK70K7QtxlydYKjie0ZssHEGxl2auOUTDcdRMBfZQBtIxQr9X8TF0+eeUUsScBXNU6xZw==
   dependencies:
     babel-eslint "^10.1.0"
     ember-template-lint "^2.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
+event-from@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/event-from/-/event-from-1.0.0.tgz#95a9f320bdd94e086a2fe076e81a7556d9994b16"
+  integrity sha512-r3eGcStSVfYo5wKcZlIiNy4qZhYeW0BKmvYv35B38k6RDWN+WJ68DOxpnX6LSGJX9hJgRoC86iwypkPUUhXd8w==
+
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"


### PR DESCRIPTION
This ensures tooltips are shown on touch-enabled laptops. It uses https://github.com/rafgraph/event-from to detect whether the last event was triggered via mouse, and if so, allows the tooltip event to propagate. (Previously, the plugin was disabled on any device that had touch capabilities.) 

The PR also fixes JS tests for Ember CLI and updates eslint-config-discourse.