### PR TITLE
UX: don't show tooltips when no text is available

### DIFF
--- a/assets/javascripts/mixins/topic-hover-extension.js
+++ b/assets/javascripts/mixins/topic-hover-extension.js
@@ -24,6 +24,10 @@ function cancel() {
 }
 
 function renderTooltip($this, text) {
+  if (!text) {
+    return;
+  }
+
   $this.after(
     `<div class='d-tooltip'><div class='d-tooltip-pointer'></div><div class='d-tooltip-content'>${text}</div></div></div>`
   );


### PR DESCRIPTION
Reported: https://meta.discourse.org/t/whats-with-this-weird-house-i-mean-arrow/270838

![Screenshot 2023-07-07 at 10 54 00 AM](https://github.com/discourse/discourse-tooltips/assets/1681963/fdd1c78c-42b1-47cd-8c4e-0092e21c0a22)


There are some cases where a post may have content like an event or a spoiler, and no other text. So we should check if there's text before attempting to display a tooltip. 
