### PR TITLE
FIX: Align topic link with topic statuses

### DIFF
--- a/assets/stylesheets/d-tooltip.scss
+++ b/assets/stylesheets/d-tooltip.scss
@@ -63,3 +63,10 @@
     line-height: 1.4em;
   }
 }
+
+.topic-list-body .link-top-line {
+  .fk-d-tooltip__trigger,
+  .fk-d-tooltip__trigger-container {
+    display: inline;
+  }
+}


### PR DESCRIPTION
Align the topic link with topic statuses when the new glimmer topic list mode is enabled.

![2025-03-07 at 01 05 35](https://github.com/user-attachments/assets/18f7a43f-6f19-4ef9-b6db-77bb7f42a263)

![2025-03-07 at 01 56 45](https://github.com/user-attachments/assets/bb2d20ce-d7c7-4649-ac92-55f31a75a6ff)

![2025-03-07 at 01 51 39](https://github.com/user-attachments/assets/7c473cf8-e3ec-4eba-8299-b4c496d3f9b7)
